### PR TITLE
Add background color configuration and make color settings look aligned; Add cell size and update time configuration options

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -14,6 +14,12 @@
           <label>Background Color</label>
           <default>#000000</default>
       </entry>
+      <entry name="updateTime" type="Int">
+          <default>1000</default>
+      </entry>
+      <entry name="cellSize" type="Int">
+          <default>10</default>
+      </entry>
   </group>
 
 </kcfg>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -6,10 +6,14 @@
   <kcfgfile name=""/>
 
   <group name="General">
-      <entry name="color" type="String">
+      <entry name="cellColor" type="String">
             <label>Color</label>
             <default>#00ff00</default>
         </entry>
+      <entry name="backgroundColor" type="String">
+          <label>Background Color</label>
+          <default>#000000</default>
+      </entry>
   </group>
 
 </kcfg>

--- a/package/contents/ui/code/life.js
+++ b/package/contents/ui/code/life.js
@@ -8,7 +8,7 @@ const State = {
 
 var cell_count_x = 0;
 var cell_count_y = 0;
-var SIZE = 10;
+var SIZE;
 
 var cells = [];
 var cells_back = [];
@@ -23,7 +23,8 @@ function fillRandom() {
     }
 }
 
-function dimensionChanged(width,height) {
+function dimensionChanged(width, height, cellSize) {
+  SIZE = cellSize;
   cell_count_x = width / SIZE;
   cell_count_y = height / SIZE;
   fillRandom();

--- a/package/contents/ui/code/life.js
+++ b/package/contents/ui/code/life.js
@@ -86,15 +86,15 @@ function advanceGeneration() {
     }
 }
 
-function paintMatrix(ctx, color){
+function paintMatrix(ctx, cellColor, backgroundColor){
     for(let y=0;y<cell_count_y;y++){
         for(let x=0;x<cell_count_x;x++) {
             let idx = y*cell_count_x+x;
             if (cells[idx] == State.ALIVE) {
-                ctx.fillStyle = color;
+                ctx.fillStyle = cellColor;
                 ctx.fillRect(x*SIZE,y*SIZE,SIZE,SIZE);
             } else {
-                ctx.fillStyle = "black";
+                ctx.fillStyle = backgroundColor;
                 ctx.fillRect(x*SIZE,y*SIZE,SIZE,SIZE);
             }
         }

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import org.kde.kirigami 2.4 as Kirigami
+import QtQuick.Controls 2.5 as QQC2
 import org.kde.kquickcontrols 2.0 as KQControls
 
 Kirigami.FormLayout {
@@ -8,6 +9,8 @@ Kirigami.FormLayout {
 
     property alias cfg_cellColor: cellColorButton.color
     property alias cfg_backgroundColor: backgroundColorButton.color
+    property alias cfg_updateTime: updateTimeSpin.value
+    property alias cfg_cellSize: cellSizeSpin.value
 
     KQControls.ColorButton {
         id: cellColorButton
@@ -19,5 +22,23 @@ Kirigami.FormLayout {
         id: backgroundColorButton
         Kirigami.FormData.label: i18n("Background color:")
         dialogTitle: i18n("Select background color")
+    }
+
+    QQC2.SpinBox {
+        id: updateTimeSpin
+        Kirigami.FormData.label: i18n("Update time (ms):")
+        from: 1
+        to: 60000
+        stepSize: 10
+        value: 1000
+    }
+
+    QQC2.SpinBox {
+        id: cellSizeSpin
+        Kirigami.FormData.label: i18n("Cell size:")
+        from: 1
+        to: 1000
+        stepSize: 1
+        value: 10
     }
 }

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -1,30 +1,23 @@
-import QtQuick
-import QtQuick.Layouts
-import QtQuick.Controls
+import QtQuick 2.0
+import org.kde.kirigami 2.4 as Kirigami
+import org.kde.kquickcontrols 2.0 as KQControls
 
-// for "units"
-import org.kde.plasma.components as PlasmaComponents
-import org.kde.kquickcontrols as KQuickControls
-import org.kde.plasma.core as PlasmaCore
-
-
-ColumnLayout {
+Kirigami.FormLayout {
     id: root
+    twinFormLayouts: parentLayout
 
-    property alias cfg_color : colorButton.color;
+    property alias cfg_cellColor: cellColorButton.color
+    property alias cfg_backgroundColor: backgroundColorButton.color
 
-    Row {
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
+    KQControls.ColorButton {
+        id: cellColorButton
+        Kirigami.FormData.label: i18n("Cell color:")
+        dialogTitle: i18n("Select cell color")
+    }
 
-        Label {
-            anchors.verticalCenter: parent.verticalCenter
-            rightPadding: 15
-            text: i18n("Cell color")
-        }
-        KQuickControls.ColorButton {
-            id: colorButton
-            dialogTitle: i18n("Select cell color")
-        }
+    KQControls.ColorButton {
+        id: backgroundColorButton
+        Kirigami.FormData.label: i18n("Background color:")
+        dialogTitle: i18n("Select background color")
     }
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -33,7 +33,7 @@ WallpaperItem {
 
         onPaint: {
             var ctx = getContext("2d");
-            Life.paintMatrix(ctx,  wallpaper.configuration.color);
+            Life.paintMatrix(ctx,  wallpaper.configuration.cellColor, wallpaper.configuration.backgroundColor);
         }
 
         onWidthChanged: {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -33,25 +33,25 @@ WallpaperItem {
 
         onPaint: {
             var ctx = getContext("2d");
-            Life.paintMatrix(ctx,  wallpaper.configuration.cellColor, wallpaper.configuration.backgroundColor);
+            Life.paintMatrix(ctx,  wallpaper.configuration.cellColor, wallpaper.configuration.backgroundColor, wallpaper.configuration.cellSize);
         }
 
         onWidthChanged: {
             stepTimer.stop();
-            Life.dimensionChanged(width, height);
+            Life.dimensionChanged(width, height, wallpaper.configuration.cellSize);
             stepTimer.start();
         }
 
         onHeightChanged: {
             stepTimer.stop();
-            Life.dimensionChanged(width, height);
+            Life.dimensionChanged(width, height, wallpaper.configuration.cellSize);
             stepTimer.start();
         }
     }
 
     Timer {
         id: stepTimer
-        interval: 1000
+        interval: wallpaper.configuration.updateTime
         repeat: true
         running: true
         triggeredOnStart: true
@@ -66,10 +66,8 @@ WallpaperItem {
 
     Component.onCompleted: {
         // Initialize the Life simulation using the actual dimensions
-        Life.dimensionChanged(width, height);
+        Life.dimensionChanged(width, height, wallpaper.configuration.cellSize);
     }
-
-
 }
 
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -33,20 +33,11 @@ WallpaperItem {
 
         onPaint: {
             var ctx = getContext("2d");
-            Life.paintMatrix(ctx,  wallpaper.configuration.cellColor, wallpaper.configuration.backgroundColor, wallpaper.configuration.cellSize);
+            Life.paintMatrix(ctx,  wallpaper.configuration.cellColor, wallpaper.configuration.backgroundColor);
         }
 
-        onWidthChanged: {
-            stepTimer.stop();
-            Life.dimensionChanged(width, height, wallpaper.configuration.cellSize);
-            stepTimer.start();
-        }
-
-        onHeightChanged: {
-            stepTimer.stop();
-            Life.dimensionChanged(width, height, wallpaper.configuration.cellSize);
-            stepTimer.start();
-        }
+        onWidthChanged: restartSimulation()
+        onHeightChanged: restartSimulation()
     }
 
     Timer {
@@ -64,9 +55,24 @@ WallpaperItem {
         }
     }
 
+    Connections {
+        target: wallpaper.configuration
+
+        function onCellSizeChanged() {
+            restartSimulation()
+        }
+    }
+
     Component.onCompleted: {
         // Initialize the Life simulation using the actual dimensions
         Life.dimensionChanged(width, height, wallpaper.configuration.cellSize);
+    }
+
+    function restartSimulation() {
+        stepTimer.stop()
+        Life.dimensionChanged(gameCanvas.width, gameCanvas.height, wallpaper.configuration.cellSize)
+        stepTimer.start()
+        gameCanvas.requestPaint()
     }
 }
 


### PR DESCRIPTION
Hi, I really like this wallpaper, but the solid black background looks pretty bad on my Mini-LED monitor. To fix that, I added a background color setting so it’s easy to switch to any color you want. The default remains black, so the existing behavior is unchanged.

<img width="2560" height="1440" alt="Screenshot_20251230_143435" src="https://github.com/user-attachments/assets/fa30ee24-afdc-4599-b911-7736936f32ea" />

Also changed the settings a bit to make it more aligned.

<img width="548" height="172" alt="image" src="https://github.com/user-attachments/assets/b4f0acca-4d06-45bc-945a-62b4350ea39e" />

Please review the PR, thank you.... ❤️
